### PR TITLE
Enable retrieving dictionaries from Structs

### DIFF
--- a/src/main/scala/weld/WeldStruct.scala
+++ b/src/main/scala/weld/WeldStruct.scala
@@ -34,6 +34,9 @@ class WeldStruct(
           case `f64` => getDouble(i)
           case Pointer => getPointer(i)
           case _: VecType => getVec(i)
+          // Dictionaries are pointers - represent them as such.
+          case _: DictMerger => getPointer(i)
+          case _: GroupMerger => getPointer(i)
           case _ =>
             throw new IllegalArgumentException(s"Unsupported struct field type[$i]: $fieldType")
         }

--- a/src/main/scala/weld/expressions/Expr.scala
+++ b/src/main/scala/weld/expressions/Expr.scala
@@ -101,7 +101,7 @@ object Literal {
     case _: Double => Literal(value, f64)
     case b: Array[Byte] => MakeVector(b.map(Literal(_, u8)))
     case s: String => MakeVector(s.getBytes.map(Literal(_, u8)))
-    case _ => throw new IllegalArgumentException(s"Cannot create a literal for: $value")
+    case _ => throw new IllegalArgumentException(s"Cannot create a literal for: $value (class=${value.getClass})")
   }
 }
 


### PR DESCRIPTION
This allows passing dictionaries and their builders between modules/runs. The dictionary is currently represented as a single pointer. The definition of a dictionary should always be in sync with the one here: https://github.com/weld-project/weld/blob/llvm-st/weld/data/mod.rs